### PR TITLE
add timeout to executor running DynamoDB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [enhancements] set executor timeout to 60. By default mirakuru waits indefinitely, which might cause test hangs
+
 1.0.0
 -------
 

--- a/src/pytest_dynamodb/factories.py
+++ b/src/pytest_dynamodb/factories.py
@@ -106,6 +106,7 @@ def dynamodb_proc(dynamodb_dir=None, host='localhost', port=None, delay=False):
             ),
             host=dynamodb_host,
             port=dynamodb_port,
+            timeout=60
         )
         dynamodb_executor.start()
         request.addfinalizer(dynamodb_executor.stop)


### PR DESCRIPTION
- should prevent any hangs, and is a return to practice from dbfixtures