### PR TITLE
Revert workaround for issue that made the dyanmodb local work as if -sharedDb was active always

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,12 +106,12 @@ You can pick which you prefer, but remember that these settings are handled in t
      - access_key
      - --dynamodb-aws_access_key
      - dynamodb_aws_access_key
-     - access_key
+     - fakeMyKeyId
    * - AWS Secret Key
      - secret_key
      - --dynamodb-aws_secret_key
      - dynamodb_aws_secret_key
-     - secret_key
+     - fakeSecretAccessKey
    * - AWS Region
      - region
      - --dynamodb-aws_region

--- a/newsfragments/1154.feature.rst
+++ b/newsfragments/1154.feature.rst
@@ -1,0 +1,1 @@
+Changed default fake credentials for Dynamodb.

--- a/pytest_dynamodb/plugin.py
+++ b/pytest_dynamodb/plugin.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         name="dynamodb_aws_secret_key",
         help=_help_aws_secret_key,
-        default="secret_key",
+        default="fakeSecretAccessKey",
     )
 
     parser.addoption(
@@ -61,7 +61,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         name="dynamodb_aws_access_key",
         help=_help_aws_access_key,
-        default="access_key",
+        default="fakeMyKeyId",
     )
 
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,7 @@ from pytest_dynamodb import factories
 dynamodb_same = factories.dynamodb("dynamodb_proc")
 dynamodb_diff = factories.dynamodb(
     "dynamodb_proc",
-    access_key="denied_key",
-    secret_key="public_key",
-#    region="eu-west-1",
+    access_key="fakeDeniedKeyId",
+    secret_key="fakeDeniedSecretAccessKey",
 )
 # pylint:enable=invalid-name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,6 @@ dynamodb_diff = factories.dynamodb(
     "dynamodb_proc",
     access_key="denied_key",
     secret_key="public_key",
-    region="eu-west-1",
+#    region="eu-west-1",
 )
 # pylint:enable=invalid-name


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.