### PR TITLE
Do not fail test pipeline if codecov fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,5 @@ jobs:
       with:
         flags: linux
         env_vars: OS, PYTHON
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/1185.feature.rst
+++ b/newsfragments/1185.feature.rst
@@ -1,0 +1,1 @@
+Do not fail test pipeline if codecov step fails.


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.