### PR TITLE
Add fixture to return aioboto3 client

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,11 @@ name = "pypi"
 
 [packages]
 pytest = "==8.0.0"
+pytest-asyncio = "==0.23.4"
 port-for = "==0.7.2"
 mirakuru = "==2.5.2"
+aioboto3 = "==12.3.0"
+types-aioboto3 = "==12.3.0"
 boto3 = "==1.34.34"
 boto3-stubs = {version = "==1.34.23", extras = ["dynamodb"]}
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ How to use
 Plugin contains two fixtures
 
 * **dynamodb** - it's a client/resource fixture that has functional scope. After each test it drops tables in DynamoDB.
+* **asyncio_dynamodb** - same as **dynamodb**, but uses the `aioboto3 <https://pypi.org/project/aioboto3/>`_ async client
 * **dynamodb_proc** - session scoped fixture, that starts DynamoDB instance at it's first use and stops at the end of the tests.
 
 Simply include one of these fixtures into your tests fixture list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,11 @@ classifiers = [
 ]
 dependencies = [
     "pytest",
+    "pytest-asyncio",
     "port-for>=0.6.0",
     "mirakuru",
+    "aioboto3",
+    "types-aioboto3[dynamodb]",
     "boto3",
     "boto3-stubs[dynamodb]",
 ]

--- a/pytest_dynamodb/plugin.py
+++ b/pytest_dynamodb/plugin.py
@@ -112,3 +112,4 @@ def pytest_addoption(parser: Parser) -> None:
 
 dynamodb_proc = factories.dynamodb_proc()
 dynamodb = factories.dynamodb("dynamodb_proc")
+asyncio_dynamodb = factories.asyncio_dynamodb("dynamodb_proc")

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -43,6 +43,43 @@ def test_dynamodb(dynamodb: DynamoDBServiceResource) -> None:
     assert item["Item"]["test_key"] == "test_value"
 
 
+@pytest.mark.asyncio
+async def test_asyncio_dynamodb(asyncio_dynamodb: DynamoDBServiceResource) -> None:
+    """Simple test for DynamoDB.
+
+    # Create a table
+    # Put an item
+    # Get the item and check the content of this item
+    """
+    # create a table
+    table = await asyncio_dynamodb.create_table(
+        TableName="Test",
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        ProvisionedThroughput={
+            "ReadCapacityUnits": 10,
+            "WriteCapacityUnits": 10,
+        },
+    )
+
+    _id = str(uuid.uuid4())
+
+    # put an item into db
+    await table.put_item(
+        Item={"id": _id, "test_key": "test_value"},
+    )
+
+    # get the item
+    item = await table.get_item(
+        Key={
+            "id": _id,
+        }
+    )
+
+    # check the content of the item
+    assert item["Item"]["test_key"] == "test_value"
+
+
 def test_if_tables_does_not_exist(dynamodb: DynamoDBServiceResource) -> None:
     """We should clear this fixture (remove all tables).
 


### PR DESCRIPTION
The asyncio client for boto3, aioboto3, takes the same arguments as boto3 itself, but as a user of pytest-dynamodb I couldn't find a simple and clean way to work out those arguments in my own code. Adding an extra fixture upstream to return an aioboto3 client is simpler and more reliable.

I briefly considered a different design where the boto3 session class was parametrizable, but that would have been more complicated because the setup and teardown code is slightly different between boto3 and aioboto3.

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.