### PR TITLE
Support Python 3.13, drop support for Python 3.8

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: towncrier check --compare-with origin/main
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", pypy-3.9]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/newsfragments/+09443f1f.feature.rst
+++ b/newsfragments/+09443f1f.feature.rst
@@ -1,0 +1,1 @@
+Declare support for Python 3.13

--- a/newsfragments/+7aff466a.break.rst
+++ b/newsfragments/+7aff466a.break.rst
@@ -1,0 +1,1 @@
+Drop support  for Python 3.8 (As it reached EOL already)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
@@ -34,7 +34,7 @@ dependencies = [
     "boto3",
     "boto3-stubs[dynamodb]",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.urls]
 "Source" = "https://github.com/ClearcodeHQ/pytest-dynamodb"
@@ -62,7 +62,7 @@ testpaths = "tests"
 
 [tool.black]
 line-length = 80
-target-version = ['py38']
+target-version = ['py39']
 include = '.*\.pyi?$'
 
 [tool.ruff]


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.