### PR TITLE
Replace TypedDict-based config with a dataclass-based config - closes…

### DIFF
--- a/newsfragments/1610.break.rst
+++ b/newsfragments/1610.break.rst
@@ -1,0 +1,5 @@
+Converted DynamoDB config from a TypedDict to a frozen dataclass.
+
+.. warning::
+
+   Update usages of `pytest_dynamodb.get_config` to attribute access.

--- a/pytest_dynamodb/config.py
+++ b/pytest_dynamodb/config.py
@@ -16,14 +16,16 @@
 # along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
 """Configuration tools for pytest-dynamodb."""
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional
 
 from _pytest.fixtures import FixtureRequest
 
 
-class PytestDynamoDBConfigType(TypedDict):
-    """Configuration type dict."""
+@dataclass(frozen=True)
+class PytestDynamoDBConfig:
+    """Configuration container."""
 
     dir: Path
     host: str
@@ -34,8 +36,8 @@ class PytestDynamoDBConfigType(TypedDict):
     aws_region: str
 
 
-def get_config(request: FixtureRequest) -> PytestDynamoDBConfigType:
-    """Return a dictionary with config options."""
+def get_config(request: FixtureRequest) -> PytestDynamoDBConfig:
+    """Return a config object with options."""
 
     def get_conf_option(option: str) -> Any:
         option_name = "dynamodb_" + option
@@ -44,16 +46,15 @@ def get_config(request: FixtureRequest) -> PytestDynamoDBConfigType:
         )
 
     port = None
-    if get_conf_option("port"):
-        port = int(get_conf_option("port"))
+    if conf_port := get_conf_option("port"):
+        port = int(conf_port)
 
-    config: PytestDynamoDBConfigType = {
-        "dir": get_conf_option("dir"),
-        "host": get_conf_option("host"),
-        "port": port,
-        "delay": bool(get_conf_option("delay")),
-        "aws_access_key": get_conf_option("aws_access_key"),
-        "aws_secret_key": get_conf_option("aws_secret_key"),
-        "aws_region": get_conf_option("aws_region"),
-    }
-    return config
+    return PytestDynamoDBConfig(
+        dir=get_conf_option("dir"),
+        host=get_conf_option("host"),
+        port=port,
+        delay=bool(get_conf_option("delay")),
+        aws_access_key=get_conf_option("aws_access_key"),
+        aws_secret_key=get_conf_option("aws_secret_key"),
+        aws_region=get_conf_option("aws_region"),
+    )

--- a/pytest_dynamodb/factories/client.py
+++ b/pytest_dynamodb/factories/client.py
@@ -63,9 +63,9 @@ def dynamodb(
         dynamo_db = boto3.resource(
             "dynamodb",
             endpoint_url=f"http://{proc_fixture.host}:{proc_fixture.port}",
-            aws_access_key_id=access_key or config["aws_access_key"],
-            aws_secret_access_key=secret_key or config["aws_secret_key"],
-            region_name=region or config["aws_region"],
+            aws_access_key_id=access_key or config.aws_access_key,
+            aws_secret_access_key=secret_key or config.aws_secret_key,
+            region_name=region or config.aws_region,
         )
         pre_existing_tables = dynamo_db.meta.client.list_tables()
         yield dynamo_db

--- a/pytest_dynamodb/factories/noprocess.py
+++ b/pytest_dynamodb/factories/noprocess.py
@@ -63,8 +63,8 @@ def dynamodb_noproc(
         """
         config = get_config(request)
 
-        dynamodb_port = port or config["port"] or 8000
-        dynamodb_host = host or config["host"]
+        dynamodb_port = port or config.port or 8000
+        dynamodb_host = host or config.host
 
         noop_exec = NoProcExecutor(dynamodb_host, dynamodb_port)
 

--- a/pytest_dynamodb/factories/process.py
+++ b/pytest_dynamodb/factories/process.py
@@ -71,7 +71,7 @@ def dynamodb_proc(
         """
         config = get_config(request)
         path_dynamodb_jar = os.path.join(
-            (dynamodb_dir or config["dir"]), "DynamoDBLocal.jar"
+            (dynamodb_dir or config.dir), "DynamoDBLocal.jar"
         )
 
         if not os.path.isfile(path_dynamodb_jar):
@@ -79,12 +79,12 @@ def dynamodb_proc(
                 "You have to provide a path to the dir with dynamodb jar file."
             )
 
-        dynamodb_port = get_port(port or config["port"])
+        dynamodb_port = get_port(port or config.port)
         assert dynamodb_port
         dynamodb_delay = (
-            "-delayTransientStatuses" if delay or config["delay"] else ""
+            "-delayTransientStatuses" if delay or config.delay else ""
         )
-        dynamodb_host = host or config["host"]
+        dynamodb_host = host or config.host
         dynamodb_executor = TCPExecutor(
             f"java -Djava.library.path=./DynamoDBLocal_lib "
             f"-jar {path_dynamodb_jar} "


### PR DESCRIPTION
… #1610

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * DynamoDB configuration must be accessed via attributes (e.g. config.host, config.port) instead of dictionary-style keys.
  * Configuration object now uses an immutable dataclass, changing the returned config type and access pattern.

* **Documentation**
  * Added a news fragment with guidance and a warning about the updated configuration access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->