### PR TITLE
Fix a bug in localhost default for dynamodb_proc

### DIFF
--- a/newsfragments/+840cd2f2.bugfix.rst
+++ b/newsfragments/+840cd2f2.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where `dynamodb_proc` always defaulted to `localhost`, ignoring `config.host` when no explicit host was passed.

--- a/pytest_dynamodb/factories/process.py
+++ b/pytest_dynamodb/factories/process.py
@@ -37,7 +37,7 @@ class JarPathException(Exception):
 
 def dynamodb_proc(
     dynamodb_dir: Optional[str] = None,
-    host: str = "localhost",
+    host: Optional[str] = None,
     port: Optional[PortType] = None,
     delay: bool = False,
 ) -> Callable[[FixtureRequest], Any]:
@@ -84,7 +84,7 @@ def dynamodb_proc(
         dynamodb_delay = (
             "-delayTransientStatuses" if delay or config.delay else ""
         )
-        dynamodb_host = host or config.host
+        dynamodb_host = host if host is not None else config.host
         dynamodb_executor = TCPExecutor(
             f"java -Djava.library.path=./DynamoDBLocal_lib "
             f"-jar {path_dynamodb_jar} "


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed an issue where DynamoDB would always use localhost for the host instead of respecting your configured host setting when no explicit value was provided. The fix enables more flexible deployments, better respect for system configuration, and proper alignment with your host preferences across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->