### PR TITLE
Replace black with ruff-format - closes #1617

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,17 +22,12 @@ repos:
       - id: detect-private-key
       - id: debug-statements
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.1.0
-    hooks:
-      - id: black
-        entry: black --config pyproject.toml .
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --respect-gitignore, --show-fixes]
+      - id: ruff-format
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.5

--- a/newsfragments/1617.misc.rst
+++ b/newsfragments/1617.misc.rst
@@ -1,0 +1,1 @@
+Replace black with ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,9 @@ xfail_strict=true
 addopts = "--max-worker-restart=0 --cov"
 testpaths = "tests"
 
-[tool.black]
-line-length = 80
-target-version = ['py39']
-include = '.*\.pyi?$'
-
 [tool.ruff]
 line-length = 100
+target-version = 'py39'
 
 [tool.ruff.lint]
 select = [
@@ -75,6 +71,8 @@ select = [
     "F",   # pyflakes
     "I",   # isort
     "D",   # pydocstyle
+    #Tryceratops
+    "TRY003",
 ]
 
 [tool.towncrier]

--- a/pytest_dynamodb/config.py
+++ b/pytest_dynamodb/config.py
@@ -41,9 +41,7 @@ def get_config(request: FixtureRequest) -> PytestDynamoDBConfig:
 
     def get_conf_option(option: str) -> Any:
         option_name = "dynamodb_" + option
-        return request.config.getoption(option_name) or request.config.getini(
-            option_name
-        )
+        return request.config.getoption(option_name) or request.config.getini(option_name)
 
     port = None
     if conf_port := get_conf_option("port"):

--- a/pytest_dynamodb/factories/client.py
+++ b/pytest_dynamodb/factories/client.py
@@ -55,8 +55,8 @@ def dynamodb(
             https://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client
         :returns: connection to DynamoDB database
         """
-        proc_fixture: Union[TCPExecutor, NoProcExecutor] = (
-            request.getfixturevalue(process_fixture_name)
+        proc_fixture: Union[TCPExecutor, NoProcExecutor] = request.getfixturevalue(
+            process_fixture_name
         )
         config = get_config(request)
 

--- a/pytest_dynamodb/factories/process.py
+++ b/pytest_dynamodb/factories/process.py
@@ -34,6 +34,13 @@ class JarPathException(Exception):
     So, we want to tell him that he has to provide a path to dynamodb dir.
     """
 
+    def __init__(self, jar_path: str) -> None:
+        """Initialize JarPathException exception."""
+        super().__init__(
+            f"Cannot find DynamoDBLocal.jar at: {jar_path}. "
+            "Provide a valid path to the directory containing the jar."
+        )
+
 
 def dynamodb_proc(
     dynamodb_dir: Optional[str] = None,
@@ -70,20 +77,14 @@ def dynamodb_proc(
         :returns: tcp executor
         """
         config = get_config(request)
-        path_dynamodb_jar = os.path.join(
-            (dynamodb_dir or config.dir), "DynamoDBLocal.jar"
-        )
+        path_dynamodb_jar = os.path.join((dynamodb_dir or config.dir), "DynamoDBLocal.jar")
 
         if not os.path.isfile(path_dynamodb_jar):
-            raise JarPathException(
-                "You have to provide a path to the dir with dynamodb jar file."
-            )
+            raise JarPathException(path_dynamodb_jar)
 
         dynamodb_port = get_port(port or config.port)
         assert dynamodb_port
-        dynamodb_delay = (
-            "-delayTransientStatuses" if delay or config.delay else ""
-        )
+        dynamodb_delay = "-delayTransientStatuses" if delay or config.delay else ""
         dynamodb_host = host if host is not None else config.host
         dynamodb_executor = TCPExecutor(
             f"java -Djava.library.path=./DynamoDBLocal_lib "

--- a/pytest_dynamodb/plugin.py
+++ b/pytest_dynamodb/plugin.py
@@ -100,9 +100,7 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_host,
     )
 
-    parser.addoption(
-        "--dynamodb-port", action="store", dest="dynamodb_port", help=_help_port
-    )
+    parser.addoption("--dynamodb-port", action="store", dest="dynamodb_port", help=_help_port)
 
     parser.addoption(
         "--dynamodb-delay",


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced Black with Ruff for formatting and updated pre-commit hooks accordingly.
  * Updated project configuration to remove Black settings, set Ruff target to Python 3.9 and tighten a Tryceratops lint rule.

* **Style**
  * Minor code formatting and small refactors across the codebase for consistency.

* **Documentation**
  * Added a newsfragment noting the formatting change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->