### PR TITLE
Extend pre-commit with check-python-version-consistency - closes #1620

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
       - id: rstcheck
         additional_dependencies: [sphinx, toml]
 
+  - repo: https://github.com/fizyk/pyproject-validator
+    rev: v0.1.0
+    hooks:
+      - id: check-python-version-consistency
+
   - repo: local
     hooks:
       - id: pipenv

--- a/newsfragments/1620.misc.rst
+++ b/newsfragments/1620.misc.rst
@@ -1,0 +1,3 @@
+Add the `check-python-version-consistency` pre-commit hook for `pyproject.toml`.
+
+This hook verifies that supported Python version declarations remain consistent.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated a new pre-commit hook to automatically validate and enforce Python version consistency within project configuration files, ensuring supported Python versions remain synchronised across all configuration sources.
  * Introduced release notes documentation describing the new Python version consistency validation feature, which provides automated monitoring of Python version declarations in project configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->