### PR TITLE
Add support for Python 3.14, drop for Python 3.9 - closes #1621

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,16 +4,15 @@ reviews:
     - path: "newsfragments/*.rst"
       instructions: |
         Validate newsfragment files:
-        1. Read valid types from [tool.towncrier.fragment] in pyproject.toml
-        2. Filename must follow the pattern: [number].[type].rst OR +[hash].[type].rst where:
-           - [number] is an issue number or PR number
-           - [type] must be one of the types defined in towncrier configuration
-        3. Content must be a clear, concise description of the change
-        4. Content should be suitable for inclusion in CHANGES.rst
-        5. Verify the type matches the nature of the change based on towncrier type definitions
-        6. Some changes may require multiple types. Especially breaking changes
-        7. Flag any files with invalid types or malformed filenames
-        8. Check that the description is meaningful (not just "fix" or "update")
+        1. Read valid types from [tool.towncrier.type] in pyproject.toml.
+        2. Filename must follow one of these patterns:
+           - `[issue_number].[type].rst` — use this when a dedicated **issue** exists in the issue tracker.
+           - `+[hash].[type].rst` — use this (orphan format) when there is NO dedicated issue. A PR alone (without a backing issue) does NOT require the numbered format; orphan is acceptable.
+           Do NOT flag orphan fragments as incorrect when only a PR exists but no issue does.
+        3. Content must be a clear, concise description of the change (not just "fix" or "update").
+        4. Content should be suitable for inclusion in CHANGES.rst.
+        5. Verify the type matches the nature of the change based on towncrier type definitions.
+        6. Some changes may require multiple types, especially breaking changes.
 
   pre_merge_checks:
     custom_checks:

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
     # Service containers to run with `container-job`
     services:
       dynamodb:
-        image: amazon/dynamodb-local:2.6.0
+        image: amazon/dynamodb-local:3.0.0
         ports:
           - 8088:8000
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/newsfragments/1621.break.rst
+++ b/newsfragments/1621.break.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.9

--- a/newsfragments/1621.feature.rst
+++ b/newsfragments/1621.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
@@ -34,7 +34,7 @@ dependencies = [
     "boto3",
     "boto3-stubs[dynamodb]",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [project.urls]
 "Source" = "https://github.com/dbfixtures/pytest-dynamodb"
@@ -63,7 +63,7 @@ testpaths = "tests"
 
 [tool.ruff]
 line-length = 100
-target-version = 'py39'
+target-version = 'py310'
 
 [tool.ruff.lint]
 select = [

--- a/pytest_dynamodb/config.py
+++ b/pytest_dynamodb/config.py
@@ -18,7 +18,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from _pytest.fixtures import FixtureRequest
 
@@ -29,7 +29,7 @@ class PytestDynamoDBConfig:
 
     dir: Path
     host: str
-    port: Optional[int]
+    port: int | None
     delay: bool
     aws_access_key: str
     aws_secret_key: str

--- a/pytest_dynamodb/factories/client.py
+++ b/pytest_dynamodb/factories/client.py
@@ -16,7 +16,7 @@
 # along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
 """Client fixture factory."""
 
-from typing import Any, Callable, Generator, Optional, Union
+from typing import Any, Callable, Generator
 
 import boto3
 import pytest
@@ -30,9 +30,9 @@ from pytest_dynamodb.factories.noprocess import NoProcExecutor
 
 def dynamodb(
     process_fixture_name: str,
-    access_key: Optional[str] = None,
-    secret_key: Optional[str] = None,
-    region: Optional[str] = None,
+    access_key: str | None = None,
+    secret_key: str | None = None,
+    region: str | None = None,
 ) -> Callable[[FixtureRequest], Any]:
     """Fixture factory for DynamoDB resource.
 
@@ -55,9 +55,7 @@ def dynamodb(
             https://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client
         :returns: connection to DynamoDB database
         """
-        proc_fixture: Union[TCPExecutor, NoProcExecutor] = request.getfixturevalue(
-            process_fixture_name
-        )
+        proc_fixture: TCPExecutor | NoProcExecutor = request.getfixturevalue(process_fixture_name)
         config = get_config(request)
 
         dynamo_db = boto3.resource(

--- a/pytest_dynamodb/factories/noprocess.py
+++ b/pytest_dynamodb/factories/noprocess.py
@@ -16,7 +16,7 @@
 # along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
 """No process fixture factory."""
 
-from typing import Any, Callable, Generator, NamedTuple, Optional
+from typing import Any, Callable, Generator, NamedTuple
 
 import pytest
 from pytest import FixtureRequest
@@ -32,8 +32,8 @@ class NoProcExecutor(NamedTuple):
 
 
 def dynamodb_noproc(
-    host: Optional[str] = None,
-    port: Optional[int] = None,
+    host: str | None = None,
+    port: int | None = None,
 ) -> Callable[[FixtureRequest], Any]:
     """Process fixture factory for DynamoDB.
 

--- a/pytest_dynamodb/factories/process.py
+++ b/pytest_dynamodb/factories/process.py
@@ -17,7 +17,7 @@
 """Process fixture factory."""
 
 import os
-from typing import Any, Callable, Generator, Optional
+from typing import Any, Callable, Generator
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -43,9 +43,9 @@ class JarPathException(Exception):
 
 
 def dynamodb_proc(
-    dynamodb_dir: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[PortType] = None,
+    dynamodb_dir: str | None = None,
+    host: str | None = None,
+    port: PortType | None = None,
     delay: bool = False,
 ) -> Callable[[FixtureRequest], Any]:
     """Process fixture factory for DynamoDB.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Dropped support for Python 3.9; minimum required version is now 3.10.

* **New Features**
  * Added support for Python 3.14.

* **Refactor**
  * Modernised type annotations across the codebase to use contemporary syntax standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->